### PR TITLE
webauthn implementation

### DIFF
--- a/privacyIDEAADFSProvider/Adapter.cs
+++ b/privacyIDEAADFSProvider/Adapter.cs
@@ -256,7 +256,7 @@ namespace privacyIDEAADFSProvider
                 response = privacyIDEA.ValidateCheck(user, otp, transactionid);
             }
 
-            // If we get this far, the login data provided was wrong or an error occured.
+            // If we get this far, the login data provided was wrong, an error occured or another challenge was triggered.
             if (response != null)
             {
                 if (response.MultiChallenge.Count > 0)
@@ -367,7 +367,6 @@ namespace privacyIDEAADFSProvider
             this.debuglog = GetFromDict(configDict, "debug_log", "0") == "1";
 
             this.triggerChallenge = GetFromDict(configDict, "trigger_challenges", "0") == "1";
-            Log("Setting trigger challenge to: " + this.triggerChallenge);
             if (!this.triggerChallenge)
             {
                 // Only if triggerChallenge is disabled, sendEmptyPassword COULD be set

--- a/privacyIDEAADFSProvider/AdapterMetadata.cs
+++ b/privacyIDEAADFSProvider/AdapterMetadata.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Globalization;
 using Microsoft.IdentityServer.Web.Authentication.External;
 
 namespace privacyIDEAADFSProvider

--- a/privacyIDEAADFSProvider/AdapterPresentationForm.cs
+++ b/privacyIDEAADFSProvider/AdapterPresentationForm.cs
@@ -1,11 +1,10 @@
 ﻿using Microsoft.IdentityServer.Web.Authentication.External;
-using System.Diagnostics;
+using PrivacyIDEASDK;
 
 namespace privacyIDEAADFSProvider
 {
     class AdapterPresentationForm : IAdapterPresentationForm
     {
-        //public UITranslation[] translations;
         public string ErrorMessage { get; set; } = "";
         public string Message { get; set; } = "";
         public string PushMessage { get; set; } = "";
@@ -16,9 +15,8 @@ namespace privacyIDEAADFSProvider
         public string OtpAvailable { get; set; } = "1";
         public string AuthCounter { get; set; } = "0";
 
-        public AdapterPresentationForm(/*UITranslation[] translations*/)
+        public AdapterPresentationForm()
         {
-            //this.translations = translations;
         }
 
         /// Returns the HTML Form fragment that contains the adapter user interface. This data will be included in the web page that is presented
@@ -28,23 +26,6 @@ namespace privacyIDEAADFSProvider
             string otptext = "One-Time-Password";
             string submittext = "Submit";
             string htmlTemplate = Resources.AuthPage;
-            /*
-            if (translations != null)
-            {
-                foreach (UITranslation translation in translations)
-                {
-                    Debug.WriteLine("ID3A_ADFSadapter: Detected language LCID:" + lcid);
-
-                    if ((int)translation.LCID == (int)lcid)
-                    {
-                        if (!string.IsNullOrEmpty(translation.errormessage)) errormessage = translation.errormessage;
-                        if (!string.IsNullOrEmpty(translation.otptext)) otptext = translation.otptext;
-                        if (!string.IsNullOrEmpty(translation.submittext)) submittext = translation.submittext;
-                        break;
-                    }
-                }
-            }
-            */
             htmlTemplate = htmlTemplate.Replace("#ERROR#", !string.IsNullOrEmpty(this.ErrorMessage) ? this.ErrorMessage : "");
             htmlTemplate = htmlTemplate.Replace("#OTPTEXT#", otptext);
             htmlTemplate = htmlTemplate.Replace("#SUBMIT#", submittext);
@@ -53,7 +34,8 @@ namespace privacyIDEAADFSProvider
             htmlTemplate = htmlTemplate.Replace("#mode#", Mode);
             htmlTemplate = htmlTemplate.Replace("#pushAvailable#", PushAvailable);
             htmlTemplate = htmlTemplate.Replace("#otpAvailable#", OtpAvailable);
-            htmlTemplate = htmlTemplate.Replace("#webAuthnSignRequest#", WebAuthnSignRequest);
+            // Replace the quotes of the WebAuthnSignRequest json string with the entity name for html
+            htmlTemplate = htmlTemplate.Replace("#webAuthnSignRequest#", WebAuthnSignRequest.Replace("\"", "&quot;"));
             htmlTemplate = htmlTemplate.Replace("#pushMessage#", PushMessage);
             htmlTemplate = htmlTemplate.Replace("#modeChanged#", "0");
             htmlTemplate = htmlTemplate.Replace("#pollInterval#", "1");

--- a/privacyIDEAADFSProvider/AuthPage.html
+++ b/privacyIDEAADFSProvider/AuthPage.html
@@ -52,6 +52,36 @@
                 document.forms["loginForm"].submit();
             }
 
+            // WEBAUTHN FUNCTIONS
+            function uint6ToB64 (nUint6) {
+                return nUint6 < 26 ?
+                    nUint6 + 65
+                    : nUint6 < 52 ?
+                        nUint6 + 71
+                        : nUint6 < 62 ?
+                            nUint6 - 4
+                            : nUint6 === 62 ?
+                                43
+                                : nUint6 === 63 ?
+                                    47
+                                    :
+                                    65;
+            };
+
+            function b64ToUint6(nChr) {
+                return nChr > 64 && nChr < 91
+                    ? nChr - 65
+                    : nChr > 96 && nChr < 123
+                        ? nChr - 71
+                        : nChr > 47 && nChr < 58
+                            ? nChr + 4
+                            : nChr === 43
+                                ? 62
+                                : nChr === 47
+                                    ? 63
+                                    : 0;
+            };
+
             function webAuthnBase64DecToArr(sBase64) {
                 return base64DecToArr(
                     sBase64
@@ -173,6 +203,59 @@
                 return aBytes;
             }
 
+            function base64DecToArr(sBase64, nBlockSize) {
+                var sB64Enc = sBase64.replace(/[^A-Za-z0-9+\/]/g, "");
+                var nInLen = sB64Enc.length;
+                var nOutLen = nBlockSize ?
+                    Math.ceil((nInLen * 3 + 1 >>> 2) / nBlockSize) * nBlockSize
+                    :
+                    nInLen * 3 + 1 >>> 2;
+                var aBytes = new Uint8Array(nOutLen);
+
+                for (var nMod3, nMod4, nUint24 = 0, nOutIdx = 0, nInIdx = 0; nInIdx < nInLen; nInIdx++) {
+                    nMod4 = nInIdx & 3;
+                    nUint24 |= b64ToUint6(sB64Enc.charCodeAt(nInIdx)) << 18 - 6 * nMod4;
+                    if (nMod4 === 3 || nInLen - nInIdx === 1) {
+                        for (nMod3 = 0; nMod3 < 3 && nOutIdx < nOutLen; nMod3++, nOutIdx++) {
+                            aBytes[nOutIdx] = nUint24 >>> (16 >>> nMod3 & 24) & 255;
+                        }
+                        nUint24 = 0;
+                    }
+                }
+
+                return aBytes;
+            };
+
+            function base64EncArr(bytes) {
+                var aBytes = new Uint8Array(bytes)
+                var eqLen = (3 - (aBytes.length % 3)) % 3;
+                var sB64Enc = "";
+
+                for (var nMod3, nLen = aBytes.length, nUint24 = 0, nIdx = 0; nIdx < nLen; nIdx++) {
+                    nMod3 = nIdx % 3;
+
+                    // Split the output in lines 76-characters long
+                    if (nIdx > 0 && (nIdx * 4 / 3) % 76 === 0) {
+                        sB64Enc += "\r\n";
+                    }
+
+                    nUint24 |= aBytes[nIdx] << (16 >>> nMod3 & 24);
+                    if (nMod3 === 2 || aBytes.length - nIdx === 1) {
+                        sB64Enc += String.fromCharCode(
+                            uint6ToB64(nUint24 >>> 18 & 63),
+                            uint6ToB64(nUint24 >>> 12 & 63),
+                            uint6ToB64(nUint24 >>> 6 & 63),
+                            uint6ToB64(nUint24 & 63));
+                        nUint24 = 0;
+                    }
+                }
+
+                return eqLen === 0 ?
+                    sB64Enc
+                    :
+                    sB64Enc.substring(0, sB64Enc.length - eqLen) + (eqLen === 1 ? "=" : "==");
+            };
+
             function webAuthnSign(webAuthnSignRequest) {
                 var publicKeyCredentialRequestOptions = {
                     challenge: webAuthnBase64DecToArr(webAuthnSignRequest.challenge),
@@ -217,6 +300,7 @@
                         return Promise.resolve(webAuthnSignResponse);
                     });
             }
+            // END WEBAUTHN FUNCTIONS
         </script>
 
         <div id="alternateTokenDiv" class="groupMargin">
@@ -297,6 +381,8 @@
                 changeMode("otp");
             }
 
+            const requestStr = value("webAuthnSignRequest");
+
             // Set origin
             if (!window.location.origin) {
                 window.location.origin = window.location.protocol + "//" + window.location.hostname + (window.location.port ? ':' + window.location.port : '');
@@ -304,12 +390,13 @@
             set("origin", window.origin);
 
             try {
-                const requestStr = value("webAuthnSignRequest");
                 const requestjson = JSON.parse(requestStr);
 
                 const webAuthnSignResponse = webAuthnSign(requestjson);
                 webAuthnSignResponse.then((webauthnresponse) => {
-                    set("webAuthnSignResponse", JSON.stringify(webauthnresponse));
+                    const response = JSON.stringify(webauthnresponse);
+                    set("webAuthnSignResponse", response);
+                    set("mode", "webauthn");
                     document.forms["loginForm"].submit();
                 });
             } catch (err) {

--- a/privacyIDEAADFSProvider/PIChallenge.cs
+++ b/privacyIDEAADFSProvider/PIChallenge.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
-namespace SDK
+namespace PrivacyIDEASDK
 {
     public class PIChallenge
     {
@@ -12,6 +8,6 @@ namespace SDK
         public string Message { get; set; } = "";
         public string TransactionID { get; set; } = "";
         public string Type { get; set; } = "";
-        public List<string> attributes { get; set; } = new List<string>();
+        public Dictionary<string, object> Attributes { get; set; } = new Dictionary<string, object>();
     }
 }

--- a/privacyIDEAADFSProvider/PILog.cs
+++ b/privacyIDEAADFSProvider/PILog.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace SDK
+namespace PrivacyIDEASDK
 {
     public interface PILog
     {

--- a/privacyIDEAADFSProvider/PIWebAuthnSignRequest.cs
+++ b/privacyIDEAADFSProvider/PIWebAuthnSignRequest.cs
@@ -1,0 +1,8 @@
+﻿
+namespace PrivacyIDEASDK
+{
+    class PIWebAuthnSignRequest: PIChallenge
+    {
+        public string WebAuthnSignRequest { get; set; } = "";
+    }
+}

--- a/privacyIDEAADFSProvider/RegistryReader.cs
+++ b/privacyIDEAADFSProvider/RegistryReader.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Microsoft.Win32;
 
-namespace privacyIDEAADFSProvider
+namespace PrivacyIDEASDK
 {
 
     public delegate void LogFunction(string message);

--- a/privacyIDEAADFSProvider/Resources.Designer.cs
+++ b/privacyIDEAADFSProvider/Resources.Designer.cs
@@ -39,7 +39,7 @@ namespace privacyIDEAADFSProvider {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("privacyIDEAADFSProvider.Resources", typeof(Resources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("PrivacyIDEAADFSProvider.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;

--- a/privacyIDEAADFSProvider/privacyIDEAADFSProvider.csproj
+++ b/privacyIDEAADFSProvider/privacyIDEAADFSProvider.csproj
@@ -7,7 +7,7 @@
     <ProjectGuid>{3A9A54D7-F23B-469C-BA61-8C69CBAF50F5}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>privacyIDEAADFSProvider</RootNamespace>
+    <RootNamespace>PrivacyIDEAADFSProvider</RootNamespace>
     <AssemblyName>privacyIDEA-ADFSProvider</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
@@ -63,6 +63,7 @@
     <Compile Include="PIChallenge.cs" />
     <Compile Include="PILog.cs" />
     <Compile Include="PIResponse.cs" />
+    <Compile Include="PIWebAuthnSignRequest.cs" />
     <Compile Include="PrivacyIDEA.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RegistryReader.cs" />


### PR DESCRIPTION
Feature (closes #1):
* Implemented PIWebAuthnSignRequest to be able to recognize when a webauthn token was triggered
* A button will be shown in the UI if a SIgnRequest is available
* Implemented ValidateCheckWebAuthn to send the SignResponse that is received from the browser to privacyIDEA

Internally:
* Fixed namespace names
* Put try-catch block around usages of dynmaic to prevent crashes
* Refactored the usage of HttpClient to use StringContent instead of FormUrlEncoded so that we can decide what to encode. (encoding the SignResponse breaks it for the server)
* SendRequest now properly uses the headers if any are passed