### PR TITLE
Overwrite old transaction id

### DIFF
--- a/privacyIDEAADFSProvider/Adapter.cs
+++ b/privacyIDEAADFSProvider/Adapter.cs
@@ -260,7 +260,7 @@ namespace privacyIDEAADFSProvider
                 }
                 else
                 {
-                    Error("Response value was false!");
+                    Log("Response value was false!");
                     // Set the error message from the response or a default
                     form.ErrorMessage = (!string.IsNullOrEmpty(response.ErrorMessage)) ? response.ErrorMessage + " (" + response.ErrorCode + ")"
                         : "Wrong OTP value!";
@@ -382,7 +382,9 @@ namespace privacyIDEAADFSProvider
 
         private void ExtractChallengeData(PIResponse response, AdapterPresentationForm form, IAuthenticationContext authContext)
         {
-            authContext.Data.Add("transactionid", response.TransactionID);
+            // explicitly overwrite here. If another challenge was triggered, it will have a different transaction_id.
+            authContext.Data["transactionid"] = response.TransactionID;
+            
             form.Message = response.Message;
 
             if (response.TriggeredTokenTypes().Contains("push"))


### PR DESCRIPTION
* Overwrite the old transaction id if another challenge is triggered.
* Removed failed authentication attempts from writing to the event log.