### PR TITLE
Add otp hint to config

### DIFF
--- a/privacyIDEAADFSProvider/AdapterPresentationForm.cs
+++ b/privacyIDEAADFSProvider/AdapterPresentationForm.cs
@@ -7,6 +7,7 @@ namespace privacyIDEAADFSProvider
     class AdapterPresentationForm : IAdapterPresentationForm
     {
         public string ErrorMessage { get; set; } = "";
+        public string OtpHint { get; set; } = "";
         public string Message { get; set; } = "";
         public string PushMessage { get; set; } = "";
         public string PushAvailable { get; set; } = "0";
@@ -50,6 +51,10 @@ namespace privacyIDEAADFSProvider
         public string GetFormHtml(int lcid)
         {
             string otptext = "One-Time-Password";
+            if (!string.IsNullOrEmpty(OtpHint))
+            {
+                otptext = OtpHint;
+            }
             string submittext = "Submit";
             string htmlTemplate = Resources.AuthPage;
 

--- a/privacyIDEAADFSProvider/PrivacyIDEA.cs
+++ b/privacyIDEAADFSProvider/PrivacyIDEA.cs
@@ -442,6 +442,13 @@ namespace PrivacyIDEASDK
                     Log("No realm configured for domain " + d);
                 }
             }
+            else
+            {
+                if (!string.IsNullOrEmpty(Realm))
+                {
+                    parameters.Add("realm", Realm);
+                }
+            }            
         }
 
         internal StringContent DictToEncodedStringContent(Dictionary<string, string> dict)


### PR DESCRIPTION
Enable to use the placeholder in the otp field to give a manually created hint for a user