### PR TITLE
Use UPN suffix as domain for realm mapping

### DIFF
--- a/privacyIDEAADFSProvider/Adapter.cs
+++ b/privacyIDEAADFSProvider/Adapter.cs
@@ -64,6 +64,10 @@ namespace privacyIDEAADFSProvider
                     UserPrincipal user = UserPrincipal.FindByIdentity(ctx, username);
                     upn = user.UserPrincipalName;
                     Log("Found UPN: " + upn);
+
+                    // Set domain to UPN suffix instead of NetBIOS domain
+                    domain = upn.Contains("@") ? upn.Split('@')[1] : domain;
+                    Log("Domain for " + upn + ": " + domain);
                 }
                 else
                 {


### PR DESCRIPTION
This solves an environment-specific issue where realm mapping needs to follow the UPN suffix. If preferred, I can rework this into an optional configuration-based behavior instead of changing the default behavior.

When UseUPN is enabled and the user's UPN is resolved from Active Directory, the code now extracts the suffix part after @ from UserPrincipalName and uses that as the domain value.

Example:
login identity: DOMAIN\user1
resolved UPN: user1@customer.example.com
previous domain value: DOMAIN
new domain value: customer.example.com

This makes it possible to map authentication requests based on UPN suffix instead of Windows domain name, which is useful in hosted or multi-customer environments where realm mapping is tied to the customer's UPN namespace. It doesn't break current behavior, becauuse it's using realm-mapping registry keys.