### PR TITLE
Pin GitHub Actions to SHAs and add zizmor security gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3
 
       - name: Restore (PackageReference + packages.config)
         # SolutionDir is required for RestorePackagesConfig (it restores the
@@ -56,7 +58,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-results
           path: TestResults/*.trx
@@ -72,7 +74,9 @@ jobs:
       contents: write  # needed to attach the SBOM asset to a release
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Generate SBOM (CycloneDX)
         shell: pwsh
@@ -82,7 +86,7 @@ jobs:
           dotnet CycloneDX privacyIDEAADFSProvider\packages.config --output sbom --json --filename bom.json
 
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom
           path: sbom/bom.json
@@ -93,4 +97,7 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ github.event.release.tag_name }}" sbom/bom.json --clobber
+          # Pass the tag through the environment rather than interpolating the
+          # GitHub context directly into the run block (avoids template injection).
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: gh release upload "$env:RELEASE_TAG" sbom/bom.json --clobber

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,13 +31,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           languages: csharp
           build-mode: manual
@@ -49,6 +51,6 @@ jobs:
           msbuild privacyIDEAADFSProvider\privacyIDEAADFSProvider.csproj /p:Configuration=Release /p:SignAssembly=false /v:minimal /nologo
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           category: "/language:csharp"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Extract changelog section for this tag
         id: changelog

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,46 @@
+name: Zizmor
+
+# Static security analysis of our own GitHub Actions workflows (zizmor).
+# Catches unpinned actions, template injection, credential persistence,
+# over-broad permissions, etc.
+#
+# This is a hard gate: the zizmor CLI exits non-zero when it finds anything,
+# which fails the job (and blocks the PR). Findings are also uploaded as SARIF
+# to the Security tab for triage. All actions here are pinned to commit SHAs
+# and zizmor itself is version-pinned, consistent with what it enforces.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write   # upload SARIF to code scanning
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        # pipx is preinstalled on ubuntu-latest. Pin the zizmor version so the
+        # gate is reproducible. Non-zero exit on findings fails the job.
+        env:
+          GH_TOKEN: ${{ github.token }}   # online audits query the GitHub API
+        run: |
+          pipx install zizmor==1.26.1
+          zizmor --format sarif . > zizmor.sarif
+
+      - name: Upload SARIF
+        if: always()   # still publish findings on the run that failed the gate
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        with:
+          sarif_file: zizmor.sarif
+          category: zizmor


### PR DESCRIPTION
Hardens our CI supply chain and adds a GitHub Actions security gate.

## Changes
- **SHA-pin every action reference.** Mutable tags (`@v4`) can be silently repointed to malicious code (cf. the tj-actions/changed-files compromise, 2025); commit-SHA pins are immutable. Adopts the versions Dependabot proposed in #64–#67: `checkout` v7, `upload-artifact` v7, `setup-msbuild` v3, `codeql-action` v4. Dependabot understands SHA pins and will keep bumping them.
- **`persist-credentials: false`** on all checkouts.
- **Fix a template-injection sink** in the SBOM release-upload step — the release tag now goes through an env var instead of being interpolated into the run block.
- **New `zizmor.yml`** — audits our workflows on every push/PR, **fails CI on any finding** (per request), and uploads SARIF to the Security tab. zizmor itself is version-pinned and all its actions are SHA-pinned.

## Validation
Ran zizmor v1.26.1 locally against all four workflows after the changes: **No findings (exit 0)** — so the new gate is green on first run.

## Supersedes
Closes #64, #65, #66, #67 — their version bumps are adopted here as SHA pins.