### PR TITLE
Scope NuGet Dependabot to non-breaking test-stack updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,21 @@ updates:
           - "Microsoft.NET.Test.Sdk"
           - "coverlet*"
           - "WireMock.Net"
+    # Hold back major-version bumps of the test stack: MSTest 4 / Test.Sdk 18 /
+    # coverlet 10 pivot to Microsoft.Testing.Platform and .NET 10 tooling, which
+    # breaks our net8.0 + vstest.console setup. Minor/patch updates still flow.
+    # Revisit as a deliberate migration, not an automated bump.
+    ignore:
+      - dependency-name: "MSTest.TestAdapter"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "MSTest.TestFramework"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "Microsoft.NET.Test.Sdk"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "coverlet.collector"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "WireMock.Net"
+        update-types: ["version-update:semver-major"]
 
   # Keep the GitHub Actions used by the CI and CodeQL workflows up to date.
   - package-ecosystem: github-actions


### PR DESCRIPTION
Adds Dependabot `ignore` rules so it no longer proposes the breaking major bumps of the test stack (MSTest 3→4, Microsoft.NET.Test.Sdk 17→18, coverlet 6→10, WireMock.Net 1→2). Those majors move to Microsoft.Testing.Platform / .NET 10 tooling and break our net8.0 + `vstest.console` setup — see closed #68. Minor/patch updates still flow automatically.

Split out from #70 because that PR merged before this config commit landed on the branch. The major upgrade will be done deliberately as its own migration when we choose to.