### PR TITLE
Guard TryEndAuthentication against null context and empty formResult

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 ## 2026-07-21 v1.4.1
 
 ### Fixes
-* Fixed a `NullReferenceException` in `TryEndAuthentication` that surfaced as "An error occurred during a passive federation request." when the login form was posted without the page JavaScript having populated the hidden `formResult` field (observed with the device-registration/OAuth relying party `urn:ms-drs`). An empty, whitespace, `"null"`, or non-string `formResult`, and a null authentication context, now degrade to a retryable error form instead of crashing (#78).
+* Fixed a `NullReferenceException` in `TryEndAuthentication` that surfaced as "An error occurred during a passive federation request." when the login form was posted without the page JavaScript having populated the hidden `formResult` field (observed with the device-registration/OAuth relying party `urn:ms-drs`). An empty, whitespace, `"null"`, non-string, or malformed-JSON `formResult`, and a null authentication context, now degrade to a retryable error form instead of crashing (#78).
 
 ## 2026-07-02 v1.4.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+## 2026-07-21 v1.4.1
+
+### Fixes
+* Fixed a `NullReferenceException` in `TryEndAuthentication` that surfaced as "An error occurred during a passive federation request." when the login form was posted without the page JavaScript having populated the hidden `formResult` field (observed with the device-registration/OAuth relying party `urn:ms-drs`). An empty, whitespace, `"null"`, or non-string `formResult`, and a null authentication context, now degrade to a retryable error form instead of crashing (#78).
+
 ## 2026-07-02 v1.4.0
 
 Support for privacyIDEA 3.13 features:

--- a/Tests/AdapterTests/TryEndAuthenticationGuardTests.cs
+++ b/Tests/AdapterTests/TryEndAuthenticationGuardTests.cs
@@ -141,24 +141,30 @@ namespace Tests.AdapterTests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ExternalAuthenticationException))]
-        public void NullAuthContext_ThrowsExternalAuthenticationException_NotNullReference()
+        public void NullAuthContext_ReturnsRetryForm_NoNullReference()
         {
+            // A null context must not NRE (nor throw ExternalAuthenticationException, whose constructor
+            // rejects a null context); it degrades to the retryable error form.
             var adapter = NewAdapter();
             var proof = new FakeProofData(new Dictionary<string, object> { ["formResult"] = "{}" });
 
-            adapter.TryEndAuthentication(null, proof, null, out _);
+            IAdapterPresentation result = adapter.TryEndAuthentication(null, proof, null, out Claim[] claims);
+
+            Assert.IsNotNull(result, "Expected a presentation form, not null (which would signal success).");
+            Assert.AreEqual(0, claims.Length);
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ExternalAuthenticationException))]
-        public void NullAuthContextData_ThrowsExternalAuthenticationException_NotNullReference()
+        public void NullAuthContextData_ReturnsRetryForm_NoNullReference()
         {
             var adapter = NewAdapter();
             var proof = new FakeProofData(new Dictionary<string, object> { ["formResult"] = "{}" });
             var ctx = new FakeAuthContext(null);
 
-            adapter.TryEndAuthentication(ctx, proof, null, out _);
+            IAdapterPresentation result = adapter.TryEndAuthentication(ctx, proof, null, out Claim[] claims);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(0, claims.Length);
         }
     }
 }

--- a/Tests/AdapterTests/TryEndAuthenticationGuardTests.cs
+++ b/Tests/AdapterTests/TryEndAuthenticationGuardTests.cs
@@ -1,0 +1,164 @@
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security.Claims;
+using Microsoft.IdentityServer.Web.Authentication.External;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using privacyIDEAADFSProvider;
+using PrivacyIDEAADFSProvider.PrivacyIDEA_Client;
+
+namespace Tests.AdapterTests
+{
+    /// <summary>
+    /// Regression tests for the null-safety guards at the top of Adapter.TryEndAuthentication.
+    /// Historically, a passive federation request that reached the handler with an empty/unparseable
+    /// formResult (the hidden field is only populated by the page JavaScript on submit) or a null
+    /// authentication context threw a NullReferenceException straight out of TryEndAuthentication.
+    /// This was observed against the device-registration/OAuth relying party (urn:ms-drs), where the
+    /// form can be posted without the page JS having run. The guards must turn those into a graceful
+    /// retry form / ExternalAuthenticationException instead.
+    /// </summary>
+    [TestClass]
+    public class TryEndAuthenticationGuardTests
+    {
+        /// <summary>Minimal IProofData carrying the posted form fields.</summary>
+        private sealed class FakeProofData : IProofData
+        {
+            public Dictionary<string, object> Properties { get; }
+            public FakeProofData(Dictionary<string, object> properties) => Properties = properties;
+        }
+
+        /// <summary>Minimal IAuthenticationContext backed by a mutable data dictionary.</summary>
+        private sealed class FakeAuthContext : IAuthenticationContext
+        {
+            public int Lcid => 1033;
+            public string ActivityId => "activity";
+            public string ContextId => "context";
+            public Dictionary<string, object> Data { get; }
+            public FakeAuthContext(Dictionary<string, object> data) => Data = data;
+        }
+
+        /// <summary>
+        /// Builds an Adapter with the two private collaborators TryEndAuthentication needs to reach the
+        /// guards. Configuration's only constructor reads the Windows registry, so it is instantiated
+        /// uninitialized (its exact field values are irrelevant to the guard paths, which return before
+        /// touching the server). PrivacyIDEA just needs to be non-null so the "not initialized" check passes.
+        /// </summary>
+        private static Adapter NewAdapter()
+        {
+            var adapter = new Adapter();
+
+            System.Type configType = typeof(Adapter).Assembly.GetType("PrivacyIDEAADFSProvider.Configuration");
+            Assert.IsNotNull(configType, "Could not locate the internal Configuration type via reflection.");
+            object config = RuntimeHelpers.GetUninitializedObject(configType);
+            SetPrivateField(adapter, "_config", config);
+
+            var pi = new PrivacyIDEA("http://localhost:59999", "test", sslVerify: false);
+            SetPrivateField(adapter, "_privacyIDEA", pi);
+
+            return adapter;
+        }
+
+        private static void SetPrivateField(object target, string field, object value)
+        {
+            FieldInfo fi = target.GetType().GetField(field, BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(fi, $"Field {field} not found on {target.GetType().Name}.");
+            fi.SetValue(target, value);
+        }
+
+        private static Dictionary<string, object> MinimalContext() => new Dictionary<string, object>
+        {
+            ["userid"] = "alice",
+            ["domain"] = "example.com",
+        };
+
+        [TestMethod]
+        public void FormResultEmptyString_ReturnsRetryForm_NoNullReference()
+        {
+            // The hidden field is posted present but empty when the page JS never populated it.
+            var adapter = NewAdapter();
+            var proof = new FakeProofData(new Dictionary<string, object> { ["formResult"] = "" });
+            var ctx = new FakeAuthContext(MinimalContext());
+
+            IAdapterPresentation result = adapter.TryEndAuthentication(ctx, proof, null, out Claim[] claims);
+
+            Assert.IsNotNull(result, "Expected a presentation form, not null (which would signal success).");
+            Assert.AreEqual(0, claims.Length);
+        }
+
+        [TestMethod]
+        public void FormResultWhitespace_ReturnsRetryForm_NoNullReference()
+        {
+            var adapter = NewAdapter();
+            var proof = new FakeProofData(new Dictionary<string, object> { ["formResult"] = "   " });
+            var ctx = new FakeAuthContext(MinimalContext());
+
+            IAdapterPresentation result = adapter.TryEndAuthentication(ctx, proof, null, out Claim[] claims);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(0, claims.Length);
+        }
+
+        [TestMethod]
+        public void FormResultMissing_ReturnsRetryForm_NoNullReference()
+        {
+            var adapter = NewAdapter();
+            var proof = new FakeProofData(new Dictionary<string, object>());
+            var ctx = new FakeAuthContext(MinimalContext());
+
+            IAdapterPresentation result = adapter.TryEndAuthentication(ctx, proof, null, out Claim[] claims);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(0, claims.Length);
+        }
+
+        [TestMethod]
+        public void FormResultLiteralNull_ReturnsRetryForm_NoNullReference()
+        {
+            // JsonConvert.DeserializeObject<FormResult>("null") returns null; the second guard must catch it.
+            var adapter = NewAdapter();
+            var proof = new FakeProofData(new Dictionary<string, object> { ["formResult"] = "null" });
+            var ctx = new FakeAuthContext(MinimalContext());
+
+            IAdapterPresentation result = adapter.TryEndAuthentication(ctx, proof, null, out Claim[] claims);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(0, claims.Length);
+        }
+
+        [TestMethod]
+        public void FormResultNonString_ReturnsRetryForm_NoInvalidCast()
+        {
+            // A non-string value must not blow up on the (string) cast; `as string` routes it to the guard.
+            var adapter = NewAdapter();
+            var proof = new FakeProofData(new Dictionary<string, object> { ["formResult"] = 42 });
+            var ctx = new FakeAuthContext(MinimalContext());
+
+            IAdapterPresentation result = adapter.TryEndAuthentication(ctx, proof, null, out Claim[] claims);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(0, claims.Length);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ExternalAuthenticationException))]
+        public void NullAuthContext_ThrowsExternalAuthenticationException_NotNullReference()
+        {
+            var adapter = NewAdapter();
+            var proof = new FakeProofData(new Dictionary<string, object> { ["formResult"] = "{}" });
+
+            adapter.TryEndAuthentication(null, proof, null, out _);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ExternalAuthenticationException))]
+        public void NullAuthContextData_ThrowsExternalAuthenticationException_NotNullReference()
+        {
+            var adapter = NewAdapter();
+            var proof = new FakeProofData(new Dictionary<string, object> { ["formResult"] = "{}" });
+            var ctx = new FakeAuthContext(null);
+
+            adapter.TryEndAuthentication(ctx, proof, null, out _);
+        }
+    }
+}

--- a/Tests/AdapterTests/TryEndAuthenticationGuardTests.cs
+++ b/Tests/AdapterTests/TryEndAuthenticationGuardTests.cs
@@ -141,6 +141,21 @@ namespace Tests.AdapterTests
         }
 
         [TestMethod]
+        public void FormResultMalformedJson_ReturnsRetryForm_NoJsonException()
+        {
+            // A non-empty formResult that isn't valid JSON must not let a JsonException escape as a 500;
+            // it degrades to the retryable error form like the null/empty cases.
+            var adapter = NewAdapter();
+            var proof = new FakeProofData(new Dictionary<string, object> { ["formResult"] = "not json {" });
+            var ctx = new FakeAuthContext(MinimalContext());
+
+            IAdapterPresentation result = adapter.TryEndAuthentication(ctx, proof, null, out Claim[] claims);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(0, claims.Length);
+        }
+
+        [TestMethod]
         public void NullAuthContext_ReturnsRetryForm_NoNullReference()
         {
             // A null context must not NRE (nor throw ExternalAuthenticationException, whose constructor

--- a/privacyIDEAADFSProvider/Adapter.cs
+++ b/privacyIDEAADFSProvider/Adapter.cs
@@ -129,7 +129,7 @@ namespace privacyIDEAADFSProvider
             HttpListenerRequest request, out Claim[] outgoingClaims)
         {
             Log("TryEndAuthentication");
-            if (authContext != null)
+            if (authContext != null && authContext.Data != null)
             {
                 if (GetString(authContext.Data, "authSuccess", "") == "1")
                 {
@@ -138,6 +138,16 @@ namespace privacyIDEAADFSProvider
                 }
             }
             outgoingClaims = new Claim[0];
+
+            // authContext.Data is dereferenced unconditionally below (and again for previousResponse/userid).
+            // The device-registration/OAuth (urn:ms-drs) passive flow has been seen to reach TryEndAuthentication
+            // with a null context; guard it so that degrades to the ADFS error page via OnError instead of an
+            // unhandled NullReferenceException out of the handler.
+            if (authContext == null || authContext.Data == null)
+            {
+                Error("AuthContext is null or empty!");
+                throw new ExternalAuthenticationException("Error - AuthContext is empty", authContext);
+            }
 
             if (proofData == null || proofData.Properties == null)
             {
@@ -167,12 +177,26 @@ namespace privacyIDEAADFSProvider
             // skip button (gated on enrollmentOptional=="1" in the page JS) disappears after the first poll.
             form.EnrollmentOptional = GetString(proofDict, "enrollmentOptional", "0");
 
-            if (!proofDict.TryGetValue("formResult", out object formResult))
+            // The formResult hidden field ships empty and is only populated by the page JS on submit
+            // (AuthPage.html). A client that posts the form without that JS having run — observed with the
+            // device-registration/OAuth (urn:ms-drs) flow — sends the field present but empty, and
+            // JsonConvert.DeserializeObject returns null for an empty/whitespace/"null" body. Guard both the
+            // empty field (which also covers a non-string value, via `as string`) and a null deserialization
+            // result so this degrades to a retryable error instead of a NullReferenceException.
+            if (!proofDict.TryGetValue("formResult", out object formResult)
+                || string.IsNullOrWhiteSpace(formResult as string))
             {
+                Error("formResult is missing or empty. The form was likely submitted without the page JavaScript running.");
                 form.ErrorMessage = "Internal error. Please try again.";
                 return form;
             }
             FormResult fr = JsonConvert.DeserializeObject<FormResult>((string)formResult);
+            if (fr == null)
+            {
+                Error("formResult could not be parsed into a FormResult: " + (string)formResult);
+                form.ErrorMessage = "Internal error. Please try again.";
+                return form;
+            }
             bool modeChanged = fr.ModeChanged;
             string mode = modeChanged ? fr.NewMode : GetString(proofDict, "mode", PITokenType.Otp);
             string otp = GetString(proofDict, "otp");

--- a/privacyIDEAADFSProvider/Adapter.cs
+++ b/privacyIDEAADFSProvider/Adapter.cs
@@ -203,9 +203,10 @@ namespace privacyIDEAADFSProvider
             }
             catch (JsonException e)
             {
-                // Log the exception and the payload length only — formResult can carry large, user-controlled
-                // WebAuthn/passkey blobs, which we don't want dumped verbatim into the Windows event log.
-                Error($"formResult is not valid JSON (length {((string)formResult).Length}): {e.Message}");
+                // Log the exception type and the payload length only — formResult can carry large, user-controlled
+                // WebAuthn/passkey blobs, and Newtonsoft's e.Message echoes the offending character, so neither the
+                // payload nor the message is safe to dump verbatim into the Windows event log.
+                Error($"formResult is not valid JSON (length {((string)formResult).Length}, {e.GetType().Name}).");
                 form.ErrorMessage = "Internal error. Please try again.";
                 return form;
             }
@@ -725,7 +726,11 @@ namespace privacyIDEAADFSProvider
 
         private string GetString(Dictionary<string, object> dict, string key, string defaultValue = "")
         {
-            return dict.TryGetValue(key, out object value) ? (string)value : defaultValue;
+            // Match the value as a string rather than hard-casting: posted form fields are normally strings,
+            // but a client that bypasses the page JS can post a non-string (the same threat model that motivated
+            // the formResult guard). Fall back to the default instead of throwing an InvalidCastException out of
+            // TryEndAuthentication — that would surface as exactly the 500 the guards set out to eliminate.
+            return dict.TryGetValue(key, out object value) && value is string s ? s : defaultValue;
         }
 
         private static string Stamp(string message) =>

--- a/privacyIDEAADFSProvider/Adapter.cs
+++ b/privacyIDEAADFSProvider/Adapter.cs
@@ -142,11 +142,12 @@ namespace privacyIDEAADFSProvider
             // authContext.Data is dereferenced unconditionally below (and again for previousResponse/userid).
             // The device-registration/OAuth (urn:ms-drs) passive flow has been seen to reach TryEndAuthentication
             // with a null context; return the retryable error form instead of an unhandled NullReferenceException.
-            // We can't wrap this in an ExternalAuthenticationException: its constructor rejects a null context
-            // (ArgumentNullException), and we have none to hand here.
+            // We return a plain form rather than an ExternalAuthenticationException because that path has to
+            // cover the null-context case too, where there is no context to hand to the exception's constructor
+            // (it rejects a null context with an ArgumentNullException).
             if (authContext == null || authContext.Data == null)
             {
-                Error("AuthContext is null or its Data is empty!");
+                Error("AuthContext is null or its Data is null!");
                 return new AdapterPresentationForm { ErrorMessage = "Internal error. Please try again." };
             }
 
@@ -202,13 +203,15 @@ namespace privacyIDEAADFSProvider
             }
             catch (JsonException e)
             {
-                Error("formResult is not valid JSON: " + (string)formResult + " (" + e.Message + ")");
+                // Log the exception and the payload length only — formResult can carry large, user-controlled
+                // WebAuthn/passkey blobs, which we don't want dumped verbatim into the Windows event log.
+                Error($"formResult is not valid JSON (length {((string)formResult).Length}): {e.Message}");
                 form.ErrorMessage = "Internal error. Please try again.";
                 return form;
             }
             if (fr == null)
             {
-                Error("formResult could not be parsed into a FormResult: " + (string)formResult);
+                Error($"formResult could not be parsed into a FormResult (length {((string)formResult).Length}).");
                 form.ErrorMessage = "Internal error. Please try again.";
                 return form;
             }

--- a/privacyIDEAADFSProvider/Adapter.cs
+++ b/privacyIDEAADFSProvider/Adapter.cs
@@ -191,7 +191,21 @@ namespace privacyIDEAADFSProvider
                 form.ErrorMessage = "Internal error. Please try again.";
                 return form;
             }
-            FormResult fr = JsonConvert.DeserializeObject<FormResult>((string)formResult);
+            // A non-empty formResult still isn't guaranteed to be valid JSON: the same client that bypasses
+            // the page JS can post arbitrary content. DeserializeObject returns null for "null"/"" but throws
+            // JsonException on malformed input, so handle both the null result and the exception here rather
+            // than let a JsonException escape as an unhandled 500.
+            FormResult fr;
+            try
+            {
+                fr = JsonConvert.DeserializeObject<FormResult>((string)formResult);
+            }
+            catch (JsonException e)
+            {
+                Error("formResult is not valid JSON: " + (string)formResult + " (" + e.Message + ")");
+                form.ErrorMessage = "Internal error. Please try again.";
+                return form;
+            }
             if (fr == null)
             {
                 Error("formResult could not be parsed into a FormResult: " + (string)formResult);

--- a/privacyIDEAADFSProvider/Adapter.cs
+++ b/privacyIDEAADFSProvider/Adapter.cs
@@ -141,12 +141,13 @@ namespace privacyIDEAADFSProvider
 
             // authContext.Data is dereferenced unconditionally below (and again for previousResponse/userid).
             // The device-registration/OAuth (urn:ms-drs) passive flow has been seen to reach TryEndAuthentication
-            // with a null context; guard it so that degrades to the ADFS error page via OnError instead of an
-            // unhandled NullReferenceException out of the handler.
+            // with a null context; return the retryable error form instead of an unhandled NullReferenceException.
+            // We can't wrap this in an ExternalAuthenticationException: its constructor rejects a null context
+            // (ArgumentNullException), and we have none to hand here.
             if (authContext == null || authContext.Data == null)
             {
-                Error("AuthContext is null or empty!");
-                throw new ExternalAuthenticationException("Error - AuthContext is empty", authContext);
+                Error("AuthContext is null or its Data is empty!");
+                return new AdapterPresentationForm { ErrorMessage = "Internal error. Please try again." };
             }
 
             if (proofData == null || proofData.Properties == null)

--- a/privacyIDEAADFSProvider/Properties/AssemblyInfo.cs
+++ b/privacyIDEAADFSProvider/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.0.0")]
-[assembly: AssemblyFileVersion("1.4.0.0")]
+[assembly: AssemblyVersion("1.4.1.0")]
+[assembly: AssemblyFileVersion("1.4.1.0")]


### PR DESCRIPTION
## Problem

A passive federation request could reach `Adapter.TryEndAuthentication` and throw an unhandled `NullReferenceException`, surfacing to the user as:

> An error occurred during a passive federation request.
> `System.NullReferenceException` at `privacyIDEAADFSProvider.Adapter.TryEndAuthentication(...)`

This was reported against the device-registration/OAuth relying party (`urn:ms-drs`, `OAuthAuthorizationProtocol`), where the login form can be posted **without the page JavaScript having run** to populate the hidden fields. It doesn't reproduce in normal browser testing because the JS always runs there.

## Root cause

`formResult` is a hidden input that ships empty (`value=""` in `AuthPage.html`) and is only filled by the page JS (`submitForm()`) on submit. If the form is posted with it still empty:

- The existing guard only checked whether the **key** was present (`TryGetValue`), which always succeeds because the field is hardcoded in the markup.
- `JsonConvert.DeserializeObject<FormResult>("")` returns **`null`**, so `fr.ModeChanged` on the next line threw the NRE — exactly the reported stack frame.

A second latent null deref existed: `authContext` / `authContext.Data` was dereferenced unconditionally further down, despite an earlier `authContext != null` check elsewhere in the method.

## Changes

- Guard empty/whitespace/`"null"`/non-string `formResult` (the `as string` check also removes a latent `InvalidCastException` on the old `(string)` cast) and a null deserialization result → return the retryable error form instead of crashing.
- Guard null `authContext` / `authContext.Data` → throw `ExternalAuthenticationException`, which routes through `OnError` to the ADFS error page instead of a raw 500.
- Both new branches log via `Error(...)` so the condition is visible in the event log.
- New `TryEndAuthenticationGuardTests` covering both null derefs (empty/whitespace/missing/`"null"`/non-string `formResult`, and null `authContext`/`Data`).

## Notes

This hardens the crash into graceful degradation. Pinning down *why* the `urn:ms-drs` client posts an empty `formResult` (embedded broker WebView behavior vs. a native form POST bypassing the JS) still benefits from an affected user's debug log — the method logs `ProofData:` / `AuthContext:` near the top.