### PR TITLE
Scope release workflow to real release tags only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,10 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      # Real release tags only: vMAJOR.MINOR.PATCH. Pre-release/dev tags such as
+      # v1.4.1dev0 deliberately do NOT trigger this job — they have no signed MSI
+      # and no dedicated changelog section, so the release flow is skipped for them.
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
## Problem

The `Release` workflow triggers on every `v*` tag. Pushing a dev/pre-release tag (`v1.4.1dev0`) therefore kicked off a release run that failed at the changelog-extraction step:

> Error: No changelog section found for tag 'v1.4.1dev0'. Add a '## <date> v1.4.1dev0' entry to Changelog.md.

That's expected — a dev snapshot has no locally signed MSI to attach and no dedicated `## <date> vX.Y.Z` changelog section, so the whole release flow is inappropriate for it.

## Change

Restrict the `on.push.tags` filter from `v*` to `v[0-9]+.[0-9]+.[0-9]+`, so only real release tags (`vMAJOR.MINOR.PATCH`) start the job. Dev/pre-release tags like `v1.4.1dev0` stay plain git tags and no longer produce a failing release run. Manual `workflow_dispatch` is unchanged for the rare case you want to build a release for an arbitrary existing tag.